### PR TITLE
feat(windows): made the App autostat after system launched.

### DIFF
--- a/app.go
+++ b/app.go
@@ -311,6 +311,16 @@ func (a *App) GetCurrentLanguage() (string, error) {
 	return common.GetCurrentLanguage(), nil
 }
 
+// SetAutoStart 设置开机自启（仅 Windows 有效，其他平台 no-op）
+func (a *App) SetAutoStart(enable bool) error {
+	return common.SetAutoStart(enable)
+}
+
+// IsAutoStartEnabled 查询开机自启状态（供前端调用）
+func (a *App) IsAutoStartEnabled() (bool, error) {
+	return common.IsAutoStartEnabled()
+}
+
 // SetLanguage 设置语言（供前端调用）
 func (a *App) SetLanguage(lang string) error {
 	err := common.SetLanguage(lang)

--- a/common/autostart_other.go
+++ b/common/autostart_other.go
@@ -1,0 +1,16 @@
+//go:build !windows
+
+package common
+
+// 非 Windows 平台：no-op 实现，保证跨平台编译通过
+// 后续可扩展：macOS -> LaunchAgent plist；Linux -> ~/.config/autostart/*.desktop
+
+// SetAutoStart 非 Windows 平台暂不支持开机自启
+func SetAutoStart(enable bool) error {
+	return nil
+}
+
+// IsAutoStartEnabled 非 Windows 平台始终返回 false
+func IsAutoStartEnabled() (bool, error) {
+	return false, nil
+}

--- a/common/autostart_windows.go
+++ b/common/autostart_windows.go
@@ -1,0 +1,81 @@
+//go:build windows
+
+package common
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"golang.org/x/sys/windows/registry"
+)
+
+// Windows 开机自启 - 使用 HKCU Run 注册表项（无需管理员权限）
+const (
+	autoStartRegPath = `Software\Microsoft\Windows\CurrentVersion\Run`
+	autoStartAppKey  = "ClipSave" // 注册表值名，必须全局唯一
+)
+
+// SetAutoStart 设置 Windows 开机自启
+// enable=true  写入注册表；enable=false 删除注册表项
+func SetAutoStart(enable bool) error {
+	key, _, err := registry.CreateKey(
+		registry.CURRENT_USER,
+		autoStartRegPath,
+		registry.SET_VALUE|registry.QUERY_VALUE,
+	)
+	if err != nil {
+		return fmt.Errorf("打开注册表失败: %w", err)
+	}
+	defer key.Close()
+
+	if enable {
+		exe, err := os.Executable()
+		if err != nil {
+			return fmt.Errorf("获取可执行文件路径失败: %w", err)
+		}
+		// 路径加引号，避免含空格时解析错误
+		cmd := fmt.Sprintf(`"%s"`, exe)
+		if err := key.SetStringValue(autoStartAppKey, cmd); err != nil {
+			return fmt.Errorf("写入注册表失败: %w", err)
+		}
+		return nil
+	}
+
+	// 关闭：删除值；不存在时视为成功
+	if err := key.DeleteValue(autoStartAppKey); err != nil {
+		if err == registry.ErrNotExist || strings.Contains(err.Error(), "cannot find") {
+			return nil
+		}
+		return fmt.Errorf("删除注册表项失败: %w", err)
+	}
+	return nil
+}
+
+// IsAutoStartEnabled 查询是否已开启开机自启
+// 返回 true 的条件：注册表存在对应键值，且值中指向的路径与当前 exe 相同
+func IsAutoStartEnabled() (bool, error) {
+	key, err := registry.OpenKey(registry.CURRENT_USER, autoStartRegPath, registry.QUERY_VALUE)
+	if err != nil {
+		if err == registry.ErrNotExist {
+			return false, nil
+		}
+		return false, err
+	}
+	defer key.Close()
+
+	val, _, err := key.GetStringValue(autoStartAppKey)
+	if err != nil {
+		if err == registry.ErrNotExist {
+			return false, nil
+		}
+		return false, err
+	}
+
+	exe, err := os.Executable()
+	if err != nil {
+		// 拿不到当前 exe 时，只要值存在就算开启
+		return val != "", nil
+	}
+	return strings.Contains(val, exe), nil
+}

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -67,6 +67,11 @@ const zhCN = {
     languageDesc: "选择应用界面语言",
     backgroundMode: "后台运行",
     backgroundModeDesc: "开启后应用将在后台运行，不显示 Dock 图标",
+    autoStart: "开机自启",
+    autoStartDesc: "开机时自动启动剪存（静默启动到后台）",
+    autoStartEnabled: "已开启开机自启",
+    autoStartDisabled: "已关闭开机自启",
+    autoStartError: "设置开机自启失败",
     donation: "赞赏支持",
     donationTitle: "请作者喝杯咖啡",
     donationDesc:
@@ -480,6 +485,11 @@ const enUS = {
     backgroundMode: "Background Mode",
     backgroundModeDesc:
       "When enabled, the app will run in the background without showing Dock icon",
+    autoStart: "Launch at Startup",
+    autoStartDesc: "Launch ClipSave automatically when the system starts (silently)",
+    autoStartEnabled: "Launch at startup enabled",
+    autoStartDisabled: "Launch at startup disabled",
+    autoStartError: "Failed to update launch at startup",
     donation: "Support",
     donationTitle: "Buy the Author a Coffee",
     donationDesc:
@@ -758,6 +768,11 @@ const frFR = {
     backgroundMode: "Mode Arrière-plan",
     backgroundModeDesc:
       "Lorsqu'il est activé, l'application fonctionnera en arrière-plan sans afficher l'icône du Dock",
+    autoStart: "Démarrage automatique",
+    autoStartDesc: "Lancer ClipSave automatiquement au démarrage du système (silencieusement)",
+    autoStartEnabled: "Démarrage automatique activé",
+    autoStartDisabled: "Démarrage automatique désactivé",
+    autoStartError: "Échec de la mise à jour du démarrage automatique",
     donation: "Soutien",
     donationTitle: "Offrez un Café à l'Auteur",
     donationDesc:
@@ -1098,6 +1113,11 @@ const arSA = {
     backgroundMode: "وضع الخلفية",
     backgroundModeDesc:
       "عند التمكين، سيعمل التطبيق في الخلفية دون عرض أيقونة Dock",
+    autoStart: "التشغيل التلقائي عند بدء التشغيل",
+    autoStartDesc: "تشغيل ClipSave تلقائياً عند بدء تشغيل النظام (بصمت)",
+    autoStartEnabled: "تم تفعيل التشغيل التلقائي",
+    autoStartDisabled: "تم تعطيل التشغيل التلقائي",
+    autoStartError: "فشل في تحديث التشغيل التلقائي",
     donation: "الدعم",
     donationTitle: "اشتري للمؤلف فنجان قهوة",
     donationDesc:

--- a/frontend/src/views/setting/setting.vue
+++ b/frontend/src/views/setting/setting.vue
@@ -128,6 +128,20 @@
           <el-switch v-model="settings.doubleClickPaste" />
         </div>
 
+        <!-- 开机自启（仅 Windows） -->
+        <div class="setting-item" v-if="isWindows">
+          <div class="setting-item-left">
+            <el-icon :size="20" class="setting-icon">
+              <Switch />
+            </el-icon>
+            <div class="setting-item-info">
+              <div class="setting-item-title">{{ $t('settings.autoStart') }}</div>
+              <div class="setting-item-desc">{{ $t('settings.autoStartDesc') }}</div>
+            </div>
+          </div>
+          <el-switch v-model="settings.autoStart" @change="handleAutoStartChange" />
+        </div>
+
         <div class="setting-item">
           <div class="setting-item-left">
             <el-icon :size="20" class="setting-icon">
@@ -311,7 +325,8 @@ import {
   Delete,
   Operation,
   Star,
-  Document
+  Document,
+  Switch
 } from "@element-plus/icons-vue";
 import HotkeyDisplay from "./components/HotkeyDisplay.vue";
 import ScriptManager from "./components/ScriptManager.vue";
@@ -327,6 +342,8 @@ import {
   SetLanguage,
   SetDockIconVisibility,
   OpenURL,
+  IsAutoStartEnabled,
+  SetAutoStart,
 } from "../../../wailsjs/go/main/App";
 
 const { t, locale } = useI18n();
@@ -343,6 +360,7 @@ const settings = ref({
   hotkey: "Command+Option+c", // 全局快捷键
   backgroundMode: false, // 后台运行模式（仅 macOS）
   doubleClickPaste: true, // 双击自动粘贴功能
+  autoStart: false, // 开机自启（仅 Windows 生效）
 });
 
 // 当前语言
@@ -350,6 +368,9 @@ const currentLanguage = ref('zh-CN');
 
 // 检测是否为 macOS
 const isMacOS = ref(navigator.platform.toUpperCase().indexOf('MAC') >= 0);
+
+// 检测是否为 Windows
+const isWindows = ref(navigator.platform.toUpperCase().indexOf('WIN') >= 0);
 
 // 原始快捷键值，用于比较是否有修改
 const originalHotkey = ref("");
@@ -438,6 +459,17 @@ async function loadSettings() {
           console.error("同步后台模式状态失败:", error);
         }
       }
+      // 同步开机自启状态（仅 Windows）：以注册表真实值为准
+      if (isWindows.value) {
+        try {
+          const realAutoStart = await IsAutoStartEnabled();
+          if (realAutoStart !== settings.value.autoStart) {
+            settings.value.autoStart = realAutoStart;
+          }
+        } catch (error) {
+          console.warn("查询开机自启状态失败:", error);
+        }
+      }
       console.log("✅ 已从数据库加载设置:", settings.value);
     } else {
       // 数据库应该已经有默认设置，如果没有则使用代码中的默认值
@@ -485,6 +517,17 @@ async function handleBackgroundModeChange(value: boolean) {
     ElMessage.error("设置后台模式失败");
     // 恢复开关状态
     settings.value.backgroundMode = !value;
+  }
+}
+
+// 处理开机自启切换（仅 Windows 生效）
+async function handleAutoStartChange(value: boolean) {
+  try {
+    await SetAutoStart(value);
+  } catch (error) {
+    console.error("设置开机自启失败:", error);
+    // 恢复开关状态
+    settings.value.autoStart = !value;
   }
 }
 

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -70,6 +70,8 @@ export function HideWindowAndQuit():Promise<void>;
 
 export function HttpRequest(arg1:string,arg2:string,arg3:string,arg4:string):Promise<string>;
 
+export function IsAutoStartEnabled():Promise<boolean>;
+
 export function IsSayPlaying():Promise<boolean>;
 
 export function IsScriptHTTPServiceEnabled(arg1:string):Promise<boolean>;
@@ -101,6 +103,8 @@ export function SayText(arg1:string):Promise<void>;
 export function SearchClipboardItems(arg1:boolean,arg2:string,arg3:string,arg4:number,arg5:boolean):Promise<Array<common.ClipboardItem>>;
 
 export function SearchItem():Promise<void>;
+
+export function SetAutoStart(arg1:boolean):Promise<void>;
 
 export function SetDockIconVisibility(arg1:number):Promise<void>;
 

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -138,6 +138,10 @@ export function HttpRequest(arg1, arg2, arg3, arg4) {
   return window['go']['main']['App']['HttpRequest'](arg1, arg2, arg3, arg4);
 }
 
+export function IsAutoStartEnabled() {
+  return window['go']['main']['App']['IsAutoStartEnabled']();
+}
+
 export function IsSayPlaying() {
   return window['go']['main']['App']['IsSayPlaying']();
 }
@@ -200,6 +204,10 @@ export function SearchClipboardItems(arg1, arg2, arg3, arg4, arg5) {
 
 export function SearchItem() {
   return window['go']['main']['App']['SearchItem']();
+}
+
+export function SetAutoStart(arg1) {
+  return window['go']['main']['App']['SetAutoStart'](arg1);
 }
 
 export function SetDockIconVisibility(arg1) {


### PR DESCRIPTION
### 这是关于什么？

感谢提供了一个 windows 上面的剪切板，此前有一直在 mac 平台上使用另一个软件 [Paste](https://pasteapp.io/),习惯了在电脑开机之后会自动记录剪切板的数据，但目前项目里面并没有加入开机自启动的功能，导致好几次想去剪切板里面找复制的历史未成功，耽误工作效率，因此修改了一些逻辑。用 HKCU 的 Run 注册表项搞定，不用管理员权限，没引入新依赖。macOS / Linux 保留 no-op 占位，后续再补。

### 思路

1. 前端通用设置里加一个「开机自启」开关，只在 Windows 下显示。
2. 开关切到 on 时，往 `HKCU\Software\Microsoft\Windows\CurrentVersion\Run` 写一个值名为 `ClipSave` 的键，值是当前可执行文件的绝对路径（带引号防止路径含空格）；切到 off 时删掉这个键。
3. 设置页打开时查一次注册表，拿真实状态回填 UI，避免前端缓存和系统实际状态脱节。
4. 失败时开关状态回滚，保持 UI 和注册表一致。

### 实现

Go 端，只依赖 `golang.org/x/sys/windows/registry`（原本就在 `go.sum` 里作为 indirect，直接引用一下变成 direct，没升级、没新增模块）：

```go
// common/autostart_windows.go
const (
    autoStartRegPath = `Software\Microsoft\Windows\CurrentVersion\Run`
    autoStartAppKey  = "ClipSave"
)

func SetAutoStart(enable bool) error {
    key, _, err := registry.CreateKey(
        registry.CURRENT_USER,
        autoStartRegPath,
        registry.SET_VALUE|registry.QUERY_VALUE,
    )
    if err != nil {
        return fmt.Errorf("打开注册表失败: %w", err)
    }
    defer key.Close()

    if enable {
        exe, err := os.Executable()
        if err != nil {
            return fmt.Errorf("获取可执行文件路径失败: %w", err)
        }
        cmd := fmt.Sprintf(`"%s"`, exe)
        return key.SetStringValue(autoStartAppKey, cmd)
    }

    if err := key.DeleteValue(autoStartAppKey); err != nil {
        if err == registry.ErrNotExist || strings.Contains(err.Error(), "cannot find") {
            return nil
        }
        return fmt.Errorf("删除注册表项失败: %w", err)
    }
    return nil
}
```

非 Windows 平台 no-op，让跨平台编译过得去：

```go
// common/autostart_other.go
//go:build !windows

func SetAutoStart(enable bool) error        { return nil }
func IsAutoStartEnabled() (bool, error)     { return false, nil }
```

`app.go` 里只是薄薄一层包装，暴露给 wails 前端调用：

```go
func (a *App) SetAutoStart(enable bool) error {
    return common.SetAutoStart(enable)
}

func (a *App) IsAutoStartEnabled() (bool, error) {
    return common.IsAutoStartEnabled()
}
```

前端 `setting.vue`，开关切换直接调后端，失败回滚：

```ts
async function handleAutoStartChange(value: boolean) {
    try {
        await SetAutoStart(value);
    } catch (error) {
        console.error("设置开机自启失败:", error);
        settings.value.autoStart = !value;
    }
}
```

### 需要补充的问题

- 只用 HKCU 写当前用户的 Run 项，不动 HKLM，所以普通用户就能改，不需要 UAC 提权，代价是只对当前用户生效。
- 开机启动后默认就是正常打开主窗口。要做「静默启动到后台」的话，需要在 `main.go` 里解析一个 `--autostart` 参数、启动时隐藏窗口，注册表写入时也要把这个参数拼到命令行后面。目前没做这层，用户如果嫌弹窗，点 X 关到托盘就行。
- macOS 的 LaunchAgent plist、Linux 的 `~/.config/autostart/*.desktop` 两套方案先留了 no-op 占位，等有人用再补，反正接口签名已经定好了。